### PR TITLE
Refresh Card UID instantly with new card

### DIFF
--- a/tile_control/src/main.cpp
+++ b/tile_control/src/main.cpp
@@ -65,11 +65,10 @@ void loop() {
       --card_timeout;
     }
   } else {
-    if (card_timeout == 0) {
-      Serial.print(F("Card UID:"));
-      dump_rfid_uid(mfrc522.uid.uidByte, mfrc522.uid.size);
-      Serial.println();
-    }
+    // Moved the card UID printing block outside the 'if (card_timeout == 0)' condition
+    Serial.print(F("Card UID:"));
+    dump_rfid_uid(mfrc522.uid.uidByte, mfrc522.uid.size);
+    Serial.println();
     card_timeout = 3;
   }
 


### PR DESCRIPTION
In the old code, the condition if (card_timeout == 0) prevents the new card's UID from being processed unless the card_timeout variable reaches zero. However, since the card_timeout variable is reset to 3 each time a new card is detected, it would never reach zero if a new card is placed near the reader before the timeout expires.
-- GPT4